### PR TITLE
MA-1000 Add a global PR template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# IDEs
+.idea
+.vscode
+
+# Misc
+**/.DS_Store

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,9 @@
+## What & Why
+<!-- Describe your change, and why you made it. -->
+
+
+
+## Proof
+<!-- A picture is worth a thousand words; provide some visual proof of your changes working -->
+
+

--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 # .github
-Default community health files for upstreamdb
+
+Default community health files for `upstreamdb`.
+
+To learn more about community health files, you can
+[read more here](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/creating-a-default-community-health-file).


### PR DESCRIPTION
# What & Why

Add a global PR template for `upstreamdb` repositories.

Unfortunately, until https://github.com/orgs/community/discussions/42499 is resolved, we will need to store this in this public `.github` repository. Once more functionality is added to `.github-private`, we can move this (and other information) there.
